### PR TITLE
fix: swap QFP and BGA mappings

### DIFF
--- a/grafana_provisioning/dashboards/PANOSETI/Examine Specific Quabo.json
+++ b/grafana_provisioning/dashboards/PANOSETI/Examine Specific Quabo.json
@@ -74,11 +74,11 @@
               "options": {
                 "0": {
                   "index": 0,
-                  "text": "BGA"
+                  "text": "QFP"
                 },
                 "1": {
                   "index": 1,
-                  "text": "QFP"
+                  "text": "BGA"
                 }
               },
               "type": "value"
@@ -535,11 +535,11 @@
               "options": {
                 "0": {
                   "index": 0,
-                  "text": "BGA"
+                  "text": "QFP"
                 },
                 "1": {
                   "index": 1,
-                  "text": "QFP"
+                  "text": "BGA"
                 }
               },
               "type": "value"
@@ -2210,11 +2210,11 @@
                   "options": {
                     "0": {
                       "index": 0,
-                      "text": "BGA"
+                      "text": "QFP"
                     },
                     "1": {
                       "index": 1,
-                      "text": "QFP"
+                      "text": "BGA"
                     }
                   },
                   "type": "value"


### PR DESCRIPTION
#1 

I updated the Grafana page on Lick to reflect the updated mapping  1 <-> BGA and  0 <-> QFP